### PR TITLE
게시글 작성 기능 추가

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import styled, { css } from "styled-components";
+
+interface Props {
+    show: boolean;
+    header: React.ReactNode;
+    main: React.ReactNode;
+    footer: React.ReactNode;
+    width: string;
+}
+
+const ModalStyle = styled.div<{show: boolean}>`
+    display: ${props => props.show ? 'flex' : 'none'};
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 99;
+    background-color: rgba(0, 0, 0, 0.6);
+    ${props => 
+        props.show &&
+        css`
+            align-items: center;
+        `
+    }
+`;
+
+const ModalSectionStyle = styled.section<{width: string}>`
+    width: 90%;
+    max-width: ${props => props.width};
+    max-height: 90%;
+    margin: 0 auto;
+    border-radius: 1rem;
+    background-color: #fff;
+    overflow: hidden;
+`;
+
+const ModalHeaderStyle = styled.header`
+    position: relative;
+    padding: 8px 8px 8px 8px;
+    background-color: #f1f1f1;
+    font-weight: 700;
+`;
+
+const ModalMainStyle = styled.main`
+    max-height: 36rem;
+    padding: 16px;
+    border-bottom: 1px solid #dee2e6;
+    border-top: 1px solid #dee2e6;
+    overflow: scroll;
+`;
+
+const ModalFooterStyle = styled.footer`
+    padding: 12px 16px;
+    text-align: right;
+`;
+
+const Modal: React.FC<Props> = (props) => {
+    return (
+        <ModalStyle show={props.show}>
+            <ModalSectionStyle width={props.width}>
+                <ModalHeaderStyle>
+                    {props.header}
+                </ModalHeaderStyle>
+                <ModalMainStyle>
+                    {props.main}
+                </ModalMainStyle>
+                <ModalFooterStyle>
+                    {props.footer}
+                </ModalFooterStyle>
+            </ModalSectionStyle>
+        </ModalStyle>
+    );
+}
+export default Modal;

--- a/src/components/PostWrite.tsx
+++ b/src/components/PostWrite.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import Modal from "./Modal";
 
 interface Props {
@@ -11,15 +11,23 @@ const PostWrite: React.FC<Props> = (props) => {
     const [title, setTitle] = useState<string>();
     const [content, setContent] = useState<string>();
 
-    const imgElem = useRef<HTMLImageElement>(null);
-    const inputImg = useRef<HTMLInputElement>(null);
-
     const onImageChange: React.ChangeEventHandler<HTMLInputElement> = e => {
         const imgFile = e.currentTarget.files![0];
         const reader = new FileReader();
         reader.readAsDataURL(imgFile);
         reader.onload = e => {
             setImage(reader.result?.toString());
+        }
+    }
+
+    const onTextChange: React.ChangeEventHandler<HTMLInputElement> = e => {
+        switch(e.currentTarget.name) {
+            case "postTitle":
+                setTitle(e.currentTarget.value);
+                break;
+            case "postContent":
+                setContent(e.currentTarget.value);
+                break;
         }
     }
 
@@ -31,8 +39,8 @@ const PostWrite: React.FC<Props> = (props) => {
             }
             main={
                 <form style={{ display: "flex", flexDirection: "column"}}>
-                    <img src={image} ref={imgElem}></img>
-                    <label>사진 업로드 : <input ref={inputImg} type="file" accept="image/png, image/jpeg" name="postImage" onChange={onImageChange}></input></label> 
+                    <img src={image}></img>
+                    <label>사진 업로드 : <input type="file" accept="image/png, image/jpeg" name="postImage" onChange={onImageChange}></input></label> 
                     <input type="text" placeholder="제목" name="postTitle"></input>
                     <textarea placeholder="내용" name="postContent"></textarea>
                 </form>

--- a/src/components/PostWrite.tsx
+++ b/src/components/PostWrite.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { FormEvent, useEffect, useState } from "react";
+import auth from "../auth";
 import Modal from "./Modal";
 
 interface Props {
@@ -20,7 +21,7 @@ const PostWrite: React.FC<Props> = (props) => {
         }
     }
 
-    const onTextChange: React.ChangeEventHandler<HTMLInputElement> = e => {
+    const onTextChange: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement> = e => {
         switch(e.currentTarget.name) {
             case "postTitle":
                 setTitle(e.currentTarget.value);
@@ -29,6 +30,18 @@ const PostWrite: React.FC<Props> = (props) => {
                 setContent(e.currentTarget.value);
                 break;
         }
+    }
+
+    const onSubmit: React.MouseEventHandler<HTMLButtonElement> = e => {
+        auth.currentUser?.getIdToken().then(idToken => {
+            const postData = {
+                token: idToken,
+                img: image,
+                title: title,
+                content: content,
+            }
+            console.log(postData);
+        });
     }
 
     return (
@@ -41,14 +54,14 @@ const PostWrite: React.FC<Props> = (props) => {
                 <form style={{ display: "flex", flexDirection: "column"}}>
                     <img src={image}></img>
                     <label>사진 업로드 : <input type="file" accept="image/png, image/jpeg" name="postImage" onChange={onImageChange}></input></label> 
-                    <input type="text" placeholder="제목" name="postTitle"></input>
-                    <textarea placeholder="내용" name="postContent"></textarea>
+                    <input type="text" placeholder="제목" name="postTitle" onChange={onTextChange}></input>
+                    <textarea placeholder="내용" name="postContent" onChange={onTextChange}></textarea>
                 </form>
             }
             footer={
                 <>
                     <button onClick={props.onClose}>취소</button>
-                    <button type="submit">작성</button>
+                    <button onClick={onSubmit}>작성</button>
                 </>
             }
             width="60rem"/>

--- a/src/components/PostWrite.tsx
+++ b/src/components/PostWrite.tsx
@@ -5,7 +5,6 @@ import Modal from "./Modal";
 
 interface Props {
     show: boolean;
-    onClose: () => void;
 }
 
 const Form = styled.form`
@@ -110,7 +109,7 @@ const PostWrite: React.FC<Props> = (props) => {
             }
             footer={
                 <>
-                    <button onClick={props.onClose}>취소</button>
+                    <button onClick={() => window.location.reload()}>취소</button>
                     <button onClick={onSubmit}>작성</button>
                 </>
             }

--- a/src/components/PostWrite.tsx
+++ b/src/components/PostWrite.tsx
@@ -65,6 +65,10 @@ const PostWrite: React.FC<Props> = (props) => {
         e.preventDefault();
         e.returnValue = '';
     }
+    
+    function preventGoBack() {
+        window.history.pushState(null, "", window.location.href);
+    }
 
     const onImageChange: React.ChangeEventHandler<HTMLInputElement> = e => {
         const imgFile = e.currentTarget.files![0];
@@ -113,10 +117,13 @@ const PostWrite: React.FC<Props> = (props) => {
 
     useEffect(() => {
         if (props.show) {
+            window.history.pushState(null, "", window.location.href);
             window.addEventListener("beforeunload", onBeforeReload);
+            window.addEventListener("popstate", preventGoBack);
         }
         else {
             window.removeEventListener("beforeunload", onBeforeReload);
+            window.removeEventListener("popstate", preventGoBack);
         }
         
     }, [props.show]);

--- a/src/components/PostWrite.tsx
+++ b/src/components/PostWrite.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import auth from "../auth";
 import Modal from "./Modal";
@@ -61,6 +61,11 @@ const PostWrite: React.FC<Props> = (props) => {
     const [title, setTitle] = useState<string>();
     const [content, setContent] = useState<string>();
 
+    function onBeforeReload(e: BeforeUnloadEvent) {
+        e.preventDefault();
+        e.returnValue = '';
+    }
+
     const onImageChange: React.ChangeEventHandler<HTMLInputElement> = e => {
         const imgFile = e.currentTarget.files![0];
         const reader = new FileReader();
@@ -92,6 +97,16 @@ const PostWrite: React.FC<Props> = (props) => {
             console.log(postData);
         });
     }
+
+    useEffect(() => {
+        if (props.show) {
+            window.addEventListener("beforeunload", onBeforeReload);
+        }
+        else {
+            window.removeEventListener("beforeunload", onBeforeReload);
+        }
+        
+    }, [props.show]);
 
     return (
         <Modal 

--- a/src/components/PostWrite.tsx
+++ b/src/components/PostWrite.tsx
@@ -87,6 +87,19 @@ const PostWrite: React.FC<Props> = (props) => {
     }
 
     const onSubmit: React.MouseEventHandler<HTMLButtonElement> = e => {
+        if (!image) {
+            alert('인증 사진 1장을 첨부해주세요!');
+            return;
+        }
+        if (!title) {
+            alert('제목을 작성해주세요!');
+            return;
+        }
+        if (!content) {
+            alert('내용을 입력해주세요!');
+            return;
+        }
+        if (!window.confirm('게시글을 작성하시겠습니까?')) return;
         auth.currentUser?.getIdToken().then(idToken => {
             const postData = {
                 token: idToken,

--- a/src/components/PostWrite.tsx
+++ b/src/components/PostWrite.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import Modal from "./Modal";
+
+interface Props {
+    show: boolean;
+    onClose: () => void;
+    onSubmit: () => void;
+}
+
+const PostWrite: React.FC<Props> = (props) => {
+    return (
+        <Modal 
+            show={props.show}
+            header={
+                <h2>내 활동 인증</h2>
+            }
+            main={
+                <form>
+                    <label>사진 업로드 : </label> 
+                    <input type="file" accept="image/png, image/jpeg"></input><br></br>
+                    <input type="text" placeholder="제목"></input><br></br>
+                    <textarea placeholder="내용"></textarea>
+                </form>
+            }
+            footer={
+                <>
+                    <button onClick={props.onClose}>취소</button>
+                    <button onClick={props.onSubmit}>작성</button>
+                </>
+            }
+            width="60rem"/>
+    );
+}
+export default PostWrite;

--- a/src/components/PostWrite.tsx
+++ b/src/components/PostWrite.tsx
@@ -1,13 +1,28 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Modal from "./Modal";
 
 interface Props {
     show: boolean;
     onClose: () => void;
-    onSubmit: () => void;
 }
 
 const PostWrite: React.FC<Props> = (props) => {
+    const [image, setImage] = useState<string>();
+    const [title, setTitle] = useState<string>();
+    const [content, setContent] = useState<string>();
+
+    const imgElem = useRef<HTMLImageElement>(null);
+    const inputImg = useRef<HTMLInputElement>(null);
+
+    const onImageChange: React.ChangeEventHandler<HTMLInputElement> = e => {
+        const imgFile = e.currentTarget.files![0];
+        const reader = new FileReader();
+        reader.readAsDataURL(imgFile);
+        reader.onload = e => {
+            setImage(reader.result?.toString());
+        }
+    }
+
     return (
         <Modal 
             show={props.show}
@@ -15,17 +30,17 @@ const PostWrite: React.FC<Props> = (props) => {
                 <h2>내 활동 인증</h2>
             }
             main={
-                <form>
-                    <label>사진 업로드 : </label> 
-                    <input type="file" accept="image/png, image/jpeg"></input><br></br>
-                    <input type="text" placeholder="제목"></input><br></br>
-                    <textarea placeholder="내용"></textarea>
+                <form style={{ display: "flex", flexDirection: "column"}}>
+                    <img src={image} ref={imgElem}></img>
+                    <label>사진 업로드 : <input ref={inputImg} type="file" accept="image/png, image/jpeg" name="postImage" onChange={onImageChange}></input></label> 
+                    <input type="text" placeholder="제목" name="postTitle"></input>
+                    <textarea placeholder="내용" name="postContent"></textarea>
                 </form>
             }
             footer={
                 <>
                     <button onClick={props.onClose}>취소</button>
-                    <button onClick={props.onSubmit}>작성</button>
+                    <button type="submit">작성</button>
                 </>
             }
             width="60rem"/>

--- a/src/components/PostWrite.tsx
+++ b/src/components/PostWrite.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent, useEffect, useState } from "react";
+import styled from "styled-components";
 import auth from "../auth";
 import Modal from "./Modal";
 
@@ -6,6 +7,55 @@ interface Props {
     show: boolean;
     onClose: () => void;
 }
+
+const Form = styled.form`
+    display: flex;
+    flex-direction: column;
+`;
+
+const PreviewImage = styled.img`
+    width: 20rem;
+    align-self: center;
+    margin: 1rem;
+`;
+
+const UploadImage = styled.label`
+    width: 150px;
+    height: 30px;
+    margin: 1rem;
+    background: #fff;
+    border: 1px solid rgb(77,77,77);
+    border-radius: 10px;
+    font-weight: 500;
+    cursor: pointer;
+    display: flex;
+    align-self: center;
+    align-items: center;
+    justify-content: center;
+    &:hover {
+        background: rgb(77,77,77);
+        color: #fff;
+    }
+`;
+
+const TitleInput = styled.input`
+    height: 2rem;
+    margin: 0.5rem;
+    padding: 0.25rem 0.5rem 0.25rem 0.5rem;
+    border: 1px solid rgb(77,77,77);
+    border-radius: 10px;
+    font-size: 16px;
+`;
+
+const ContentTextArea = styled.textarea`
+    resize: none;
+    height: 10rem;
+    margin: 0.5rem;
+    padding: 0.5rem;
+    border: 1px solid rgb(77,77,77);
+    border-radius: 10px;
+    font-size: 14px;
+`;
 
 const PostWrite: React.FC<Props> = (props) => {
     const [image, setImage] = useState<string>();
@@ -51,12 +101,12 @@ const PostWrite: React.FC<Props> = (props) => {
                 <h2>내 활동 인증</h2>
             }
             main={
-                <form style={{ display: "flex", flexDirection: "column"}}>
-                    <img src={image}></img>
-                    <label>사진 업로드 : <input type="file" accept="image/png, image/jpeg" name="postImage" onChange={onImageChange}></input></label> 
-                    <input type="text" placeholder="제목" name="postTitle" onChange={onTextChange}></input>
-                    <textarea placeholder="내용" name="postContent" onChange={onTextChange}></textarea>
-                </form>
+                <Form>
+                    <PreviewImage src={image}></PreviewImage>
+                    <UploadImage>사진 업로드<input type="file" accept="image/png, image/jpeg" name="postImage" onChange={onImageChange} style={{display: "none"}}></input></UploadImage> 
+                    <TitleInput type="text" placeholder="제목을 입력하세요." name="postTitle" onChange={onTextChange}></TitleInput>
+                    <ContentTextArea placeholder="내용을 입력하세요." name="postContent" onChange={onTextChange}></ContentTextArea>
+                </Form>
             }
             footer={
                 <>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { signInWithPopup, GoogleAuthProvider, signOut, setPersistence, browserSessionPersistence, onAuthStateChanged } from 'firebase/auth'
+import { onAuthStateChanged } from 'firebase/auth'
 import auth, {signInGoogle, signOutGoogle} from '../auth'
 
 const Login: React.FC = () => {

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -9,7 +9,7 @@ const Post: React.FC = () => {
         <div>
             <h1>Post page</h1>
             <button onClick={() => auth.currentUser ? setWriteMode(true) : window.alert('로그인이 필요한 서비스입니다.')}>작성</button>
-            <PostWrite show={isWriteMode} onClose={() => setWriteMode(false)}/>
+            <PostWrite show={isWriteMode}/>
         </div>
     );
 }

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -1,9 +1,14 @@
-import React from "react";
+import React, { useState } from "react";
+import PostWrite from "../components/PostWrite";
 
 const Post: React.FC = () => {
+    const [isWriteMode, setWriteMode] = useState<boolean>(false);
+
     return (
         <div>
             <h1>Post page</h1>
+            <button onClick={() => setWriteMode(true)}>작성</button>
+            <PostWrite show={isWriteMode} onClose={() => setWriteMode(false)} onSubmit={() => console.log('submit')}/>
         </div>
     );
 }

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -8,7 +8,7 @@ const Post: React.FC = () => {
         <div>
             <h1>Post page</h1>
             <button onClick={() => setWriteMode(true)}>작성</button>
-            <PostWrite show={isWriteMode} onClose={() => setWriteMode(false)} onSubmit={() => console.log('submit')}/>
+            <PostWrite show={isWriteMode} onClose={() => setWriteMode(false)}/>
         </div>
     );
 }

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import auth from "../auth";
 import PostWrite from "../components/PostWrite";
 
 const Post: React.FC = () => {
@@ -7,7 +8,7 @@ const Post: React.FC = () => {
     return (
         <div>
             <h1>Post page</h1>
-            <button onClick={() => setWriteMode(true)}>작성</button>
+            <button onClick={() => auth.currentUser ? setWriteMode(true) : window.alert('로그인이 필요한 서비스입니다.')}>작성</button>
             <PostWrite show={isWriteMode} onClose={() => setWriteMode(false)}/>
         </div>
     );


### PR DESCRIPTION
## Summary
Post 페이지에 게시글 작성 팝업창 추가

## Description
- 팝업 다이얼로그 창을 만들 수 있는 Modal 컴포넌트를 생성했습니다.
- Modal 컴포넌트를 바탕으로 게시글을 작성하는 PostWrite 컴포넌트를 생성했습니다.
- 의도치 않은 새로고침 방지를 위해 PostWrite 컴포넌트에 beforeunload 이벤트 리스너를 적용했습니다.
- PostWrite 컴포넌트에 뒤로가기 방지 기능을 적용했습니다.
- PostWrite 컴포넌트에서 작성 버튼 클릭시 콘솔 로그에 게시글 데이터(이미지, 제목, 내용, 토큰)를 임시로 출력하게 했습니다.

우선 기본적인 기능만 추가해봤읍니다.
페이지는 따로 안만들었고 그냥 팝업창 띄워서 게시글 작성할 수 있게 해봤는데 괜찮은지 모르겠네요.

그리고 백엔드 작업 끝나면 axios로 요청 넣는 것만 추가하면 될 듯?

이거 디자인도 해야되는데
아...
CSS 시러요